### PR TITLE
Add feature to close session from outside

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -10,6 +10,13 @@ export type ExprCommand = ["expr", string, number?];
 
 export type CallCommand = ["call", string, unknown[], number?];
 
+export type Command =
+  | RedrawCommand
+  | ExCommand
+  | NormalCommand
+  | ExprCommand
+  | CallCommand;
+
 export function isRedrawCommand(data: unknown): data is RedrawCommand {
   return (
     Array.isArray(data) &&

--- a/deps.ts
+++ b/deps.ts
@@ -3,3 +3,4 @@ export { deferred } from "https://deno.land/x/std@0.93.0/async/deferred.ts";
 export type {
   Deferred,
 } from "https://deno.land/x/std@0.93.0/async/deferred.ts";
+export type { Disposable } from "https://deno.land/x/disposable@v0.2.0/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,2 +1,3 @@
 export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
 export { delay } from "https://deno.land/std@0.92.0/async/mod.ts";
+export { using } from "https://deno.land/x/disposable@v0.2.0/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.92.0/testing/asserts.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,1 +1,2 @@
 export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.92.0/async/mod.ts";

--- a/example/server.ts
+++ b/example/server.ts
@@ -1,22 +1,23 @@
 import { Message, Session } from "../mod.ts";
+import { using } from "../deps_test.ts";
 
 // NOTE:
 // Do NOT use 'console.log()' while stdout is used to communicate with Vim
 
 console.warn("Session has connected");
-const server = new Session(Deno.stdin, Deno.stdout, (message: Message) => {
-  console.warn(`Unexpected message ${message} has received`);
-});
 
-server
-  .listen()
-  .then(() => console.warn("Client has disconnected"))
-  .catch((e) => console.error(e));
-
-console.warn(await server.redraw());
-console.warn(await server.ex("echo 'Hello'"));
-console.warn(await server.normal("vsp"));
-console.warn(await server.expr("v:version"));
-console.warn(await server.exprNoReply("v:version"));
-console.warn(await server.call("getcwd"));
-console.warn(await server.callNoReply("getcwd"));
+await using(
+  new Session(Deno.stdin, Deno.stdout, (message: Message) => {
+    console.warn(`Unexpected message ${message} has received`);
+  }),
+  async (server) => {
+    console.warn(await server.redraw());
+    console.warn(await server.ex("echo 'Hello'"));
+    console.warn(await server.normal("vsp"));
+    console.warn(await server.expr("v:version"));
+    console.warn(await server.exprNoReply("v:version"));
+    console.warn(await server.call("getcwd"));
+    console.warn(await server.callNoReply("getcwd"));
+  },
+);
+console.warn("Client has disconnected");

--- a/indexer.ts
+++ b/indexer.ts
@@ -1,0 +1,30 @@
+/**
+ * Indexer returns sequential index
+ */
+export class Indexer {
+  #max: number;
+  #val: number;
+
+  constructor(max?: number) {
+    if (max != null && max < 2) {
+      throw new Error(
+        `The attribute 'max' must be greater than 1 but ${max} has specified`,
+      );
+    }
+    this.#max = max ?? Number.MAX_SAFE_INTEGER;
+    this.#val = -1;
+  }
+
+  /**
+   * Increment the internal index and return it
+   *
+   * It resets the internal index if it beyonds the max.
+   */
+  next(): number {
+    if (this.#val >= this.#max) {
+      this.#val = -1;
+    }
+    this.#val += 1;
+    return this.#val;
+  }
+}

--- a/indexer_test.ts
+++ b/indexer_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals, assertThrows } from "./deps_test.ts";
+import { Indexer } from "./indexer.ts";
+
+Deno.test("Indexer without 'max' works as expect", () => {
+  const indexer = new Indexer();
+  assertEquals(indexer.next(), 0);
+  assertEquals(indexer.next(), 1);
+  assertEquals(indexer.next(), 2);
+});
+
+Deno.test("Indexer with 'max' works as expect", () => {
+  const indexer = new Indexer(3);
+  assertEquals(indexer.next(), 0);
+  assertEquals(indexer.next(), 1);
+  assertEquals(indexer.next(), 2);
+  assertEquals(indexer.next(), 3);
+  assertEquals(indexer.next(), 0);
+});
+
+Deno.test("Indexer with 'max' smaller than 2 throws error", () => {
+  assertThrows(() => new Indexer(1), undefined, "must be greater than 1");
+});

--- a/message.ts
+++ b/message.ts
@@ -1,4 +1,6 @@
-export type Message = [number, unknown];
+export type MessageId = number;
+
+export type Message = [MessageId, unknown];
 
 export function isMessage(data: unknown): data is Message {
   return (

--- a/response_waiter.ts
+++ b/response_waiter.ts
@@ -1,0 +1,78 @@
+import { Deferred, deferred } from "./deps.ts";
+import { Message, MessageId } from "./message.ts";
+
+const DEFAULT_RESPONSE_TIMEOUT = 10000; // milliseconds
+
+type Waiter = {
+  timer: number;
+  response: Deferred<Message>;
+};
+
+export class TimeoutError extends Error {
+  constructor() {
+    super("the process didn't complete in time");
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * ResponseWaiter is for waiting a response messages for 'msgid'
+ */
+export class ResponseWaiter {
+  #waiters: Map<MessageId, Waiter>;
+  #timeout: number;
+
+  constructor(timeout = DEFAULT_RESPONSE_TIMEOUT) {
+    this.#waiters = new Map();
+    this.#timeout = timeout;
+  }
+
+  /**
+   * The number of internal waiters
+   */
+  get waiterCount(): number {
+    return this.#waiters.size;
+  }
+
+  /**
+   * Wait a response message of 'msgid'
+   */
+  wait(msgid: MessageId, timeout?: number): Promise<Message> {
+    let response = this.#waiters.get(msgid)?.response;
+    if (!response) {
+      response = deferred();
+      const timer = setTimeout(() => {
+        const response = this.#waiters.get(msgid)?.response;
+        if (!response) {
+          return;
+        }
+        response.reject(new TimeoutError());
+        this.#waiters.delete(msgid);
+      }, timeout ?? this.#timeout);
+      this.#waiters.set(msgid, {
+        timer,
+        response,
+      });
+    }
+    return response;
+  }
+
+  /**
+   * Provide a response message
+   *
+   * It returns false if no one seems to wait the message.
+   * Otherwise it returns true.
+   */
+  provide(message: Message): boolean {
+    const [msgid, _data] = message;
+    const waiter = this.#waiters.get(msgid);
+    if (!waiter) {
+      return false;
+    }
+    this.#waiters.delete(msgid);
+    const { timer, response } = waiter;
+    clearTimeout(timer);
+    response.resolve(message);
+    return true;
+  }
+}

--- a/response_waiter_test.ts
+++ b/response_waiter_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals, assertThrowsAsync } from "./deps_test.ts";
+import { Message, MessageId } from "./message.ts";
+import { ResponseWaiter, TimeoutError } from "./response_waiter.ts";
+
+Deno.test({
+  name: "ReseponseWaiter.wait() waits a response message",
+  fn: async () => {
+    const msgid: MessageId = 0;
+    const waiter = new ResponseWaiter();
+    const consumer = async () => {
+      const promise = waiter.wait(msgid);
+      assertEquals(waiter.waiterCount, 1);
+      const [_msgid, result] = await promise;
+      assertEquals(waiter.waiterCount, 0);
+      return result;
+    };
+    const producer = async () => {
+      await Promise.resolve();
+      const message: Message = [msgid, "OK"];
+      waiter.provide(message);
+    };
+    const result = await Promise.all([consumer(), producer()]);
+    assertEquals(result, ["OK", undefined]);
+  },
+});
+
+Deno.test({
+  name:
+    "ReseponseWaiter.wait() throws TimeoutError and remove the internal waiter",
+  fn: async () => {
+    const msgid: MessageId = 0;
+    const waiter = new ResponseWaiter();
+    await assertThrowsAsync(async () => {
+      const promise = waiter.wait(msgid, 1);
+      assertEquals(waiter.waiterCount, 1);
+      await promise;
+    }, TimeoutError);
+    assertEquals(waiter.waiterCount, 0);
+  },
+});

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,4 @@
-import { io } from "./deps.ts";
+import { Deferred, deferred, io } from "./deps.ts";
 import { isMessage, Message } from "./message.ts";
 import * as command from "./command.ts";
 import { Indexer } from "./indexer.ts";
@@ -32,6 +32,9 @@ export class Session {
   #reader: Deno.Reader;
   #writer: Deno.Writer;
   #callback: Callback;
+  #listener: Promise<void>;
+  #closed: boolean;
+  #closedSignal: Deferred<never>;
 
   /**
    * Constructor
@@ -49,6 +52,11 @@ export class Session {
     this.#reader = reader;
     this.#writer = writer;
     this.#callback = callback;
+    this.#closed = false;
+    this.#closedSignal = deferred();
+    this.#listener = this.listen().catch((e) => {
+      console.error(`Unexpected error occured: ${e}`);
+    });
   }
 
   private async send(data: Message | command.Command): Promise<void> {
@@ -58,19 +66,22 @@ export class Session {
     );
   }
 
-  /**
-   * Listen messages and handle request/response/notification.
-   * This method must be called to start session.
-   */
-  async listen(): Promise<void> {
-    const stream = io.readLines(this.#reader);
+  private async listen(): Promise<void> {
+    const iter = io.readLines(this.#reader);
     try {
-      for await (const text of stream) {
-        if (!text) {
+      while (!this.#closed) {
+        const { done, value } = await Promise.race([
+          this.#closedSignal,
+          iter.next(),
+        ]);
+        if (done) {
+          return;
+        }
+        if (!value.trim()) {
           continue;
         }
         try {
-          const data = JSON.parse(text);
+          const data = JSON.parse(value);
           if (!isMessage(data)) {
             console.warn(`Unexpected data received: ${data}`);
             continue;
@@ -81,11 +92,14 @@ export class Session {
             continue;
           }
         } catch (e) {
-          console.warn(`Failed to parse received text '${text}': ${e}`);
+          console.warn(`Failed to parse received text '${value}': ${e}`);
           continue;
         }
       }
     } catch (e) {
+      if (e instanceof SessionClosedError) {
+        return;
+      }
       // https://github.com/denoland/deno/issues/5194#issuecomment-631987928
       if (e instanceof Deno.errors.BadResource) {
         return;
@@ -94,27 +108,57 @@ export class Session {
     }
   }
 
+  /**
+   * Close this session
+   */
+  close(): void {
+    this.#closed = true;
+    this.#closedSignal.reject(new SessionClosedError());
+  }
+
+  /**
+   * Wait until the session is closed
+   */
+  waitClosed(): Promise<void> {
+    return this.#listener;
+  }
+
   async reply(msgid: number, expr: unknown): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: Message = [msgid, expr];
     await this.send(data);
   }
 
   async redraw(force = false): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: command.RedrawCommand = ["redraw", force ? "force" : ""];
     await this.send(data);
   }
 
   async ex(expr: string): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: command.ExCommand = ["ex", expr];
     await this.send(data);
   }
 
   async normal(expr: string): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: command.NormalCommand = ["normal", expr];
     await this.send(data);
   }
 
   async expr(expr: string): Promise<unknown> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const msgid = this.#indexer.next();
     const data: command.ExprCommand = ["expr", expr, msgid];
     const [_, response] = await Promise.all([
@@ -125,11 +169,17 @@ export class Session {
   }
 
   async exprNoReply(expr: string): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: command.ExprCommand = ["expr", expr];
     await this.send(data);
   }
 
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const msgid = this.#indexer.next();
     const data: command.CallCommand = ["call", fn, args, msgid];
     const [_, response] = await Promise.all([
@@ -140,6 +190,9 @@ export class Session {
   }
 
   async callNoReply(fn: string, ...args: unknown[]): Promise<void> {
+    if (this.#closed) {
+      throw new SessionClosedError();
+    }
     const data: command.CallCommand = ["call", fn, args];
     await this.send(data);
   }
@@ -149,5 +202,15 @@ export class Session {
    */
   replaceCallback(callback: Callback): void {
     this.#callback = callback;
+  }
+}
+
+/**
+ * An error indicates that the session is closed
+ */
+export class SessionClosedError extends Error {
+  constructor() {
+    super("The session is closed");
+    this.name = "SessionClosedError";
   }
 }

--- a/session.ts
+++ b/session.ts
@@ -52,7 +52,10 @@ export class Session {
   }
 
   private async send(data: Message | command.Command): Promise<void> {
-    await io.writeAll(this.#writer, utf8Encoder.encode(JSON.stringify(data)));
+    await io.writeAll(
+      this.#writer,
+      utf8Encoder.encode(JSON.stringify(data) + "\n"),
+    );
   }
 
   /**

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,4 @@
-import { Deferred, deferred, io } from "./deps.ts";
+import { Deferred, deferred, Disposable, io } from "./deps.ts";
 import { isMessage, Message } from "./message.ts";
 import * as command from "./command.ts";
 import { Indexer } from "./indexer.ts";
@@ -26,7 +26,7 @@ export type SessionOptions = {
 /**
  * Vim's channel-command Session
  */
-export class Session {
+export class Session implements Disposable {
   #indexer: Indexer;
   #waiter: ResponseWaiter;
   #reader: Deno.Reader;
@@ -106,6 +106,10 @@ export class Session {
       }
       throw e;
     }
+  }
+
+  dispose() {
+    this.close();
   }
 
   /**

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,4 @@
-import { Deferred, deferred, io } from "./deps.ts";
+iutf8Encoder.encode(JSON.stringify(data)));mport { Deferred, deferred, io } from "./deps.ts";
 import { isMessage, Message } from "./message.ts";
 import * as command from "./command.ts";
 
@@ -50,7 +50,7 @@ export class Session {
   }
 
   private async send(data: Uint8Array): Promise<void> {
-    await io.writeAll(this.#writer, data);
+    await io.writeAll(this.#writer, utf8Encoder.encode(JSON.stringify(data)));
   }
 
   /**
@@ -92,22 +92,22 @@ export class Session {
 
   async reply(msgid: number, expr: unknown): Promise<void> {
     const data: Message = [msgid, expr];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   async redraw(force = false): Promise<void> {
     const data: command.RedrawCommand = ["redraw", force ? "force" : ""];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   async ex(expr: string): Promise<void> {
     const data: command.ExCommand = ["ex", expr];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   async normal(expr: string): Promise<void> {
     const data: command.NormalCommand = ["normal", expr];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   async expr(expr: string): Promise<unknown> {
@@ -115,13 +115,13 @@ export class Session {
     const data: command.ExprCommand = ["expr", expr, msgid];
     const reply: Deferred<Message> = deferred();
     this.#replies[msgid] = reply;
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
     return (await reply)[1];
   }
 
   async exprNoReply(expr: string): Promise<void> {
     const data: command.ExprCommand = ["expr", expr];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
@@ -129,13 +129,13 @@ export class Session {
     const data: command.CallCommand = ["call", fn, args, msgid];
     const reply: Deferred<Message> = deferred();
     this.#replies[msgid] = reply;
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
     return (await reply)[1];
   }
 
   async callNoReply(fn: string, ...args: unknown[]): Promise<void> {
     const data: command.CallCommand = ["call", fn, args];
-    await this.send(utf8Encoder.encode(JSON.stringify(data)));
+    await this.send(data);
   }
 
   /**

--- a/session_test.ts
+++ b/session_test.ts
@@ -1,0 +1,294 @@
+import { io } from "./deps.ts";
+import { assertEquals, delay } from "./deps_test.ts";
+import { Session } from "./session.ts";
+import * as command from "./command.ts";
+
+const utf8Encoder = new TextEncoder();
+
+type Dispatcher = {
+  redraw: (this: Vim, data: command.RedrawCommand) => void | Promise<void>;
+  ex: (this: Vim, data: command.ExCommand) => void | Promise<void>;
+  normal: (this: Vim, data: command.NormalCommand) => void | Promise<void>;
+  expr: (this: Vim, data: command.ExprCommand) => void | Promise<void>;
+  call: (this: Vim, data: command.CallCommand) => void | Promise<void>;
+};
+
+class Reader implements Deno.Reader, Deno.Closer {
+  #queue: Uint8Array[];
+  #remain: Uint8Array;
+  #closed: boolean;
+
+  constructor(queue: Uint8Array[]) {
+    this.#queue = queue;
+    this.#remain = new Uint8Array();
+    this.#closed = false;
+  }
+
+  close(): void {
+    this.#closed = true;
+  }
+
+  async read(p: Uint8Array): Promise<number | null> {
+    if (this.#remain.length) {
+      return this.readFromRemain(p);
+    }
+    while (!this.#closed || this.#queue.length) {
+      const v = this.#queue.shift();
+      if (v) {
+        this.#remain = v;
+        return this.readFromRemain(p);
+      }
+      await delay(1);
+    }
+    return null;
+  }
+
+  private readFromRemain(p: Uint8Array): number {
+    const size = p.byteLength;
+    const head = this.#remain.slice(0, size);
+    this.#remain = this.#remain.slice(size);
+    p.set(head);
+    return head.byteLength;
+  }
+}
+
+class Writer implements Deno.Writer {
+  #queue: Uint8Array[];
+
+  constructor(queue: Uint8Array[]) {
+    this.#queue = queue;
+  }
+
+  write(p: Uint8Array): Promise<number> {
+    this.#queue.push(p);
+    return Promise.resolve(p.length);
+  }
+}
+
+class Vim {
+  #reader: Deno.Reader;
+  #writer: Deno.Writer;
+  #dispatcher: Dispatcher;
+
+  constructor(
+    reader: Deno.Reader,
+    writer: Deno.Writer,
+    dispatcher: Partial<Dispatcher>,
+  ) {
+    this.#reader = reader;
+    this.#writer = writer;
+    this.#dispatcher = {
+      redraw(data) {
+        throw new Error(`Unexpected call: ${data}`);
+      },
+      ex(data) {
+        throw new Error(`Unexpected call: ${data}`);
+      },
+      normal(data) {
+        throw new Error(`Unexpected call: ${data}`);
+      },
+      expr(data) {
+        throw new Error(`Unexpected call: ${data}`);
+      },
+      call(data) {
+        throw new Error(`Unexpected call: ${data}`);
+      },
+      ...dispatcher,
+    };
+  }
+
+  async send(data: unknown): Promise<void> {
+    await io.writeAll(
+      this.#writer,
+      utf8Encoder.encode(JSON.stringify(data) + "\n"),
+    );
+  }
+
+  async listen(): Promise<void> {
+    for await (const line of io.readLines(this.#reader)) {
+      const record = line.trim();
+      if (!record) {
+        continue;
+      }
+      const data = JSON.parse(record);
+      if (command.isRedrawCommand(data)) {
+        this.#dispatcher.redraw.call(this, data);
+      } else if (command.isExCommand(data)) {
+        this.#dispatcher.ex.call(this, data);
+      } else if (command.isNormalCommand(data)) {
+        this.#dispatcher.normal.call(this, data);
+      } else if (command.isExprCommand(data)) {
+        this.#dispatcher.expr.call(this, data);
+      } else if (command.isCallCommand(data)) {
+        this.#dispatcher.call.call(this, data);
+      } else {
+        throw new Error(`Unexpected data received: ${data}`);
+      }
+    }
+  }
+}
+
+Deno.test("Session can invoke 'redraw'", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    redraw(data) {
+      const [_, expr] = data;
+      assertEquals(expr, "");
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  await session.redraw();
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'ex'", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    ex(data) {
+      const [_, expr] = data;
+      assertEquals(expr, "echo 'Hello'");
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  await session.ex("echo 'Hello'");
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'normal'", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    normal(data) {
+      const [_, expr] = data;
+      assertEquals(expr, "<C-w>p");
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  await session.normal("<C-w>p");
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'expr'", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    async expr(data) {
+      const [_, expr, msgid] = data;
+      assertEquals(expr, "v:version");
+      assertEquals(msgid, 0);
+      await this.send([msgid, "800"]);
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  assertEquals(await session.expr("v:version"), "800");
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'expr' without reply", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    expr(data) {
+      const [_, expr, msgid] = data;
+      assertEquals(expr, "v:version");
+      assertEquals(msgid, undefined);
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  await session.exprNoReply("v:version");
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'call'", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    async call(data) {
+      const [_, fn, args, msgid] = data;
+      assertEquals(fn, "say");
+      assertEquals(args, ["John Titor"]);
+      assertEquals(msgid, 0);
+      await this.send([msgid, `Hello ${args[0]} from Remote`]);
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  assertEquals(
+    await session.call("say", "John Titor"),
+    "Hello John Titor from Remote",
+  );
+  // Close
+  sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});
+
+Deno.test("Session can invoke 'call' without reply", async () => {
+  const s2v: Uint8Array[] = []; // Local to Remote
+  const v2s: Uint8Array[] = []; // Remote to Local
+  const sr = new Reader(v2s);
+  const sw = new Writer(s2v);
+  const session = new Session(sr, sw);
+  const vr = new Reader(s2v);
+  const vw = new Writer(v2s);
+  const vim = new Vim(vr, vw, {
+    call(data) {
+      const [_, fn, args, msgid] = data;
+      assertEquals(fn, "say");
+      assertEquals(args, ["John Titor"]);
+      assertEquals(msgid, undefined);
+    },
+  });
+  const listeners = [session.listen(), vim.listen()];
+  await session.callNoReply("say", "John Titor"),
+    // Close
+    sr.close();
+  vr.close();
+  await Promise.all(listeners);
+});


### PR DESCRIPTION
The session could not close (abort) after `listen()` in previous implementation.
This PR fixes it by adding the `close()` method and automatically start the session in the constructor.

To implement that, this PR applied some internal refactorings too.

For convenience, now `Session` supports `Disposable` provided by https://deno.land/x/disposable

See also: https://github.com/lambdalisue/deno-msgpack-rpc/pull/14