### PR TITLE
:bug: fix doc test

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -21,7 +21,7 @@ type Session = {
  *
  * @example
  * ```ts
- * import { channel } from "https://deno.land/x/streamtools/mod.ts";
+ * import { channel } from "https://deno.land/x/streamtools@v0.5.0/mod.ts";
  * import { Session, Client } from "./mod.ts";
  *
  * const input = channel<Uint8Array>();


### PR DESCRIPTION
Since the version is not specified, the latest `streamtools@v1.0.0` is referenced.
However, since this version supports JSR, the following error occurs in doctest.

```
error: Relative import path "@std/bytes" not prefixed with / or ./ or ../
    at https://deno.land/x/streamtools@v1.0.0/read_all.ts:1:24
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the import source for the `channel` module to ensure compatibility and stability with the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->