### PR TITLE
:bug: returns rejected Promise instead throws Error

### DIFF
--- a/session.ts
+++ b/session.ts
@@ -70,12 +70,12 @@ export class Session {
 
   /**
    * Send a command or a message to the peer.
+   * If the session is not running, the promise will be rejected with {@link Error}.
    * @param data The data to send.
-   * @throws If the session is not running.
    */
   send(data: Command | Message): Promise<void> {
     if (!this.#running) {
-      throw new Error("Session is not running");
+      return Promise.reject(new Error("Session is not running"));
     }
     const { innerWriter } = this.#running;
     return innerWriter.write(data);
@@ -83,14 +83,13 @@ export class Session {
 
   /**
    * Receive a message from the peer.
+   * If the session is not running or the message ID is already reserved, the promise will be rejected with {@link Error}.
    * @param msgid The message ID to receive.
    * @returns The received message.
-   * @throws If the session is not running.
-   * @throws If the message ID is already reserved.
    */
   recv(msgid: number): Promise<Message> {
     if (!this.#running) {
-      throw new Error("Session is not running");
+      return Promise.reject(new Error("Session is not running"));
     }
     const { reservator } = this.#running;
     return reservator.reserve(msgid);
@@ -157,12 +156,12 @@ export class Session {
 
   /**
    * Wait until the session is shutdown.
+   * If the session is not running, the promise will be rejected with {@link Error}.
    * @returns A promise that is fulfilled when the session is shutdown.
-   * @throws If the session is not running.
    */
   wait(): Promise<void> {
     if (!this.#running) {
-      throw new Error("Session is not running");
+      return Promise.reject(new Error("Session is not running"));
     }
     const { waiter } = this.#running;
     return waiter;
@@ -170,12 +169,12 @@ export class Session {
 
   /**
    * Shutdown the session.
+   * If the session is not running, the promise will be rejected with {@link Error}.
    * @returns A promise that is fulfilled when the session is shutdown.
-   * @throws If the session is not running.
    */
   shutdown(): Promise<void> {
     if (!this.#running) {
-      throw new Error("Session is not running");
+      return Promise.reject(new Error("Session is not running"));
     }
     // Abort consumer to shutdown session properly.
     const { consumerController, waiter } = this.#running;
@@ -185,12 +184,12 @@ export class Session {
 
   /**
    * Shutdown the session forcibly.
+   * If the session is not running, the promise will be rejected with {@link Error}.
    * @returns A promise that is fulfilled when the session is shutdown.
-   * @throws If the session is not running.
    */
   forceShutdown(): Promise<void> {
     if (!this.#running) {
-      throw new Error("Session is not running");
+      return Promise.reject(new Error("Session is not running"));
     }
     // Abort consumer and producer to shutdown session forcibly.
     const { consumerController, producerController, waiter } = this.#running;

--- a/session_test.ts
+++ b/session_test.ts
@@ -48,7 +48,7 @@ Deno.test("Session.send", async (t) => {
       const { session } = createDummySession();
 
       const command = buildRedrawCommand();
-      assertThrows(
+      assertRejects(
         () => session.send(command),
         Error,
         "Session is not running",
@@ -95,7 +95,7 @@ Deno.test("Session.recv", async (t) => {
     () => {
       const { session } = createDummySession();
 
-      assertThrows(() => session.recv(-1), Error, "Session is not running");
+      assertRejects(() => session.recv(-1), Error, "Session is not running");
     },
   );
 
@@ -161,7 +161,7 @@ Deno.test("Session.wait", async (t) => {
     () => {
       const { session } = createDummySession();
 
-      assertThrows(() => session.wait(), Error, "Session is not running");
+      assertRejects(() => session.wait(), Error, "Session is not running");
     },
   );
 
@@ -200,7 +200,7 @@ Deno.test("Session.shutdown", async (t) => {
     () => {
       const { session } = createDummySession();
 
-      assertThrows(() => session.shutdown(), Error, "Session is not running");
+      assertRejects(() => session.shutdown(), Error, "Session is not running");
     },
   );
 
@@ -251,7 +251,7 @@ Deno.test("Session.forceShutdown", async (t) => {
     () => {
       const { session } = createDummySession();
 
-      assertThrows(
+      assertRejects(
         () => session.forceShutdown(),
         Error,
         "Session is not running",


### PR DESCRIPTION
It is a bad pattern to throw an error in a function whose return type is Promise.
When to handle multiple promises such as `Promise.all([...])`, if there is a function that throws an error, unhandledrejection will occur due to the rejection of other Promises.

In `Client.prototype.call()`, when session is closed, `this.#recv(...)` returns a rejected Promise and `this.#session.send(...)` throws an Error, then the rejected Promise is not handled anyone and unhundledrejection is occured.

https://github.com/vim-denops/deno-vim-channel-command/blob/6729a74749f7c7fb1ea721c4f89e28896a79ebc4/client.ts#L148-L151

```
Unhandled rejection: Error: Session is not running
    at Session.recv (file:///work/vim/deno-vim-channel-command/session.ts:93:13)
    at Client.#recv (file:///work/vim/deno-vim-channel-command/client.ts:67:47)
    at Client.call (file:///work/vim/deno-vim-channel-command/client.ts:149:17)
    at Vim.call (file:///work/vim/denops.vim/denops/@denops-private/host/vim.ts:51:39)
    ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in session management functions to ensure users receive clear feedback when attempting operations on non-running sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->