### PR TITLE
:herb: Use `unimplemented` in @std/assert

### DIFF
--- a/client_test.ts
+++ b/client_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, unimplemented } from "@std/assert";
 import {
   assertSpyCallArgs,
   assertSpyCalls,
@@ -6,7 +6,6 @@ import {
   spy,
   stub,
 } from "@std/testing/mock";
-import { unimplemented } from "@lambdalisue/errorutil";
 import { Indexer } from "@lambdalisue/indexer";
 import { buildMessage, type Message } from "./message.ts";
 import { Client, type Session } from "./client.ts";

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -18,7 +18,6 @@
   },
   "imports": {
     "@lambdalisue/async": "jsr:@lambdalisue/async@^2.1.1",
-    "@lambdalisue/errorutil": "jsr:@lambdalisue/errorutil@^1.0.0",
     "@lambdalisue/indexer": "jsr:@lambdalisue/indexer@^1.0.0",
     "@lambdalisue/reservator": "jsr:@lambdalisue/reservator@^1.0.1",
     "@lambdalisue/streamtools": "jsr:@lambdalisue/streamtools@^1.0.0",


### PR DESCRIPTION
Reduced depdendency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal dependencies and removed unused imports in the configuration and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->